### PR TITLE
Add referer and depth to Page if HTTP#fetch_pages has an error

### DIFF
--- a/lib/polipus/http.rb
+++ b/lib/polipus/http.rb
@@ -53,7 +53,7 @@ module Polipus
         puts e.backtrace
       end
 
-      [Page.new(url, :error => e)]
+      [Page.new(url, error: e, referer: referer, depth: depth)]
     end
 
     #


### PR DESCRIPTION
Might be necessary for #15

I would feel much better, if we would not rescue from `StandardError` but from the errors which are related to fetching a page (HTTP or connectivity error)
