### PR TITLE
Track url added by #add_url

### DIFF
--- a/lib/polipus.rb
+++ b/lib/polipus.rb
@@ -334,7 +334,7 @@ module Polipus
     def add_url(url, params = {})
       page = Page.new(url, params)
       yield(page) if block_given?
-      url_tracker.visit(to_track(@options[:include_query_string_in_saved_page] ? url.to_s : url.to_s.gsub(/\?.*$/,'')))
+      url_tracker.visit(@options[:include_query_string_in_saved_page] ? url.to_s : url.to_s.gsub(/\?.*$/,''))
       @internal_queue << page.to_json
     end
 


### PR DESCRIPTION
I found urls added by `#add_url` (manually or at the beginning of `#takeover`) are not tracked by `url_tracker`

This commit adds `url_tracker.visit` to `#add_url`

My question is, what is after this change the difference between `#add_url` and the private method `#enqueue`?

I have a second question regarding `#enqueue`.

``` ruby
def(enqueue url_to_visit, current_page, queue)
```

why does `#enqueue` require a queue as attribute? Would it not be possible to use `@internal_queue`?
