### PR TITLE
Add support for all redirect status codes

### DIFF
--- a/lib/polipus/page.rb
+++ b/lib/polipus/page.rb
@@ -126,7 +126,7 @@ module Polipus
     # otherwise.
     #
     def redirect?
-      (300..307).include?(@code)
+      (300...400).include?(@code)
     end
 
     #


### PR DESCRIPTION
`Page#redirect?` does not support 308.
See http://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_Redirection
