### PR TITLE
Fix #58: Support for non UTF-8 pages.

### DIFF
--- a/lib/polipus/page.rb
+++ b/lib/polipus/page.rb
@@ -3,6 +3,8 @@ require 'nokogiri'
 require 'json'
 require 'ostruct'
 require 'set'
+require 'kconv'
+
 module Polipus
   class Page
     # The URL of the page
@@ -80,7 +82,15 @@ module Polipus
     #
     def doc
       return @doc if @doc
-      @doc = Nokogiri::HTML(@body) if @body && html? rescue nil
+      noko_en_id = {
+        Kconv::UTF8 => 'UTF-8',
+        Kconv::EUC => 'EUC-JP',
+        Kconv::SJIS => 'SHIFT-JIS',
+        Kconv::ASCII => 'ASCII',
+        Kconv::JIS => 'ISO-2022-JP'
+      }[Kconv.guess(@body || '')]
+
+      @doc = Nokogiri::HTML(@body, nil, noko_en_id) if @body && html? rescue nil
     end
 
     #


### PR DESCRIPTION
Fix #58 . 
Now Japanese pages should work.