### PR TITLE
Revert 59 fix utf8 support

### DIFF
--- a/lib/polipus/page.rb
+++ b/lib/polipus/page.rb
@@ -3,6 +3,8 @@ require 'nokogiri'
 require 'json'
 require 'ostruct'
 require 'set'
+require 'kconv'
+
 module Polipus
   class Page
     # The URL of the page
@@ -80,7 +82,7 @@ module Polipus
     #
     def doc
       return @doc if @doc
-      @doc = Nokogiri::HTML(@body) if @body && html? rescue nil
+      @doc = Nokogiri::HTML(@body.toutf8, nil, 'utf-8') if @body && html? rescue nil
     end
 
     #

--- a/lib/polipus/page.rb
+++ b/lib/polipus/page.rb
@@ -3,8 +3,6 @@ require 'nokogiri'
 require 'json'
 require 'ostruct'
 require 'set'
-require 'kconv'
-
 module Polipus
   class Page
     # The URL of the page
@@ -82,15 +80,7 @@ module Polipus
     #
     def doc
       return @doc if @doc
-      noko_en_id = {
-        Kconv::UTF8 => 'UTF-8',
-        Kconv::EUC => 'EUC-JP',
-        Kconv::SJIS => 'SHIFT-JIS',
-        Kconv::ASCII => 'ASCII',
-        Kconv::JIS => 'ISO-2022-JP'
-      }[Kconv.guess(@body || '')]
-
-      @doc = Nokogiri::HTML(@body, nil, noko_en_id) if @body && html? rescue nil
+      @doc = Nokogiri::HTML(@body) if @body && html? rescue nil
     end
 
     #


### PR DESCRIPTION
I found a better way to handle these weird Japanese charsets.
With the previous version I manually specified the encoding in Nokogiri::HTML.
But it seems SHIFT-JIS is not quite supported by Nokogiri.
So now I'm using kconv String#toutf8 monkeypatch to convert the source to utf8 and set the Nokogiri encoding to utf-8. It works well and is much safer (and simpler). 