### PR TITLE
Edit regular expression in charge of removing anchor, simply add 'colon'

### DIFF
--- a/lib/polipus/page.rb
+++ b/lib/polipus/page.rb
@@ -177,7 +177,7 @@ module Polipus
       # remove anchor
       link =
         begin
-          URI.encode(URI.decode(valid_link.gsub(/#[a-zA-Z0-9_-]*$/, '')))
+          URI.encode(URI.decode(valid_link.gsub(/#[a-zA-Z0-9_:-]*$/, '')))
         rescue URI::Error
           return nil
         end


### PR DESCRIPTION
I found that urls containing anchors like "#sku:123" (e.g a semi-colon) were not cleaned up when passed to the `to_absolute` method . As a consequence, they were escaped and added to the queue of the crawler, which led to 404 errors. This kind of bug is related to the issue I described [here](https://github.com/taganaka/polipus/issues/57).

To fix it, this commit adds a colon in the regular expression used to remove anchor from urls in the `to_absolute` method.
